### PR TITLE
Fix typo in container registry domain

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on:
       - "v*"
 
 env:
-  REGISTRY: ghrc.io # Image registry, ghcr.io incase of GitHub Container Registry
+  REGISTRY: ghcr.io # Image registry, ghcr.io incase of GitHub Container Registry
   IMAGE_NAME: ${{ github.repository }}
 
 permissions:


### PR DESCRIPTION
Hi `rvigo/github_action_test`!

This is not an automatic, 🤖-generated PR, as you can check in my [GitHub profile](https://github.com/p-), I work for GitHub and I am part of the [GitHub Security Lab](https://securitylab.github.com/).

While performing a code search for container registry domains we noticed that this repo contains a misspelled domain name.

If a malicious actor were in control of that misspelled domain, they could potentially perform an attack on the software supply chain of this project and/or steal the credentials used to connect to the container registry (depending on how the misspelled domain name of the container registry is used).
Please fix this typo and check your documentation for similar typos.